### PR TITLE
Apim 7497 api secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 ## Category
 
-`secret-provider` (Gravitee v4.2 and above)
+`secret-provider`
+
+## Compatibility Matrix
+
+| Gravitee Version | Secret Provider AWS | Product |
+|------------------|---------------------|---------|
+| 4.2.x            | 1.0.x               | All     |
+| 4.6.x            | 2.0.0               | All     |
+
 
 ## Overview
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,8 @@
     <description>Plugin to fetch secrets from Kubernetes</description>
 
     <properties>
-        <gravitee-node.version>7.0.0-alpha.5</gravitee-node.version>
         <gravitee-bom.version>8.1.19</gravitee-bom.version>
-        <gravitee-secret-api.version>1.0.0-alpha.1</gravitee-secret-api.version>
+        <gravitee-secret-api.version>1.0.0-APIM-7497-api-secrets-SNAPSHOT</gravitee-secret-api.version>
 
         <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
 
@@ -61,13 +60,6 @@
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node</artifactId>
-                <version>${gravitee-node.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-            <dependency>
                 <groupId>io.gravitee.kubernetes</groupId>
                 <artifactId>gravitee-kubernetes-client</artifactId>
                 <version>${gravitee-kubernetes.version}</version>
@@ -81,12 +73,6 @@
     </dependencyManagement>
 
     <dependencies>
-        
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>io.gravitee.secret</groupId>
             <artifactId>gravitee-secret-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <gravitee-bom.version>8.1.19</gravitee-bom.version>
-        <gravitee-secret-api.version>1.0.0-APIM-7497-api-secrets-SNAPSHOT</gravitee-secret-api.version>
+        <gravitee-secret-api.version>1.0.0-alpha.1</gravitee-secret-api.version>
 
         <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,12 @@
     <description>Plugin to fetch secrets from Kubernetes</description>
 
     <properties>
-        <gravitee-node.version>5.11.0</gravitee-node.version>
-        <gravitee-bom.version>6.0.35</gravitee-bom.version>
-        <gravitee-kubernetes.version>3.1.0</gravitee-kubernetes.version>
+        <gravitee-node.version>7.0.0-alpha.5</gravitee-node.version>
+        <gravitee-bom.version>8.1.19</gravitee-bom.version>
+        <gravitee-secret-api.version>1.0.0-alpha.1</gravitee-secret-api.version>
+
+        <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
+
         <maven-plugin-assembly.version>3.7.1</maven-plugin-assembly.version>
         <maven-plugin-prettier.version>0.21</maven-plugin-prettier.version>
         <maven-plugin-prettier.prettierjava.version>2.0.0</maven-plugin-prettier.prettierjava.version>
@@ -69,6 +72,11 @@
                 <artifactId>gravitee-kubernetes-client</artifactId>
                 <version>${gravitee-kubernetes.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.secret</groupId>
+                <artifactId>gravitee-secret-api</artifactId>
+                <version>${gravitee-secret-api.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -80,6 +88,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.gravitee.secret</groupId>
+            <artifactId>gravitee-secret-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.gravitee.kubernetes</groupId>
             <artifactId>gravitee-kubernetes-client</artifactId>
             <scope>provided</scope>
@@ -87,6 +100,11 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-rx-java3</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
     <description>Plugin to fetch secrets from Kubernetes</description>
 
     <properties>
-        <gravitee-bom.version>8.1.19</gravitee-bom.version>
-        <gravitee-secret-api.version>1.0.0-APIM-7497-api-secrets-SNAPSHOT</gravitee-secret-api.version>
+        <gravitee-bom.version>8.1.20</gravitee-bom.version>
+        <gravitee-secret-api.version>1.0.0-alpha.2</gravitee-secret-api.version>
 
         <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <gravitee-bom.version>8.1.19</gravitee-bom.version>
-        <gravitee-secret-api.version>1.0.0-alpha.1</gravitee-secret-api.version>
+        <gravitee-secret-api.version>1.0.0-APIM-7497-api-secrets-SNAPSHOT</gravitee-secret-api.version>
 
         <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
 

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
@@ -2,7 +2,9 @@ package io.gravitee.secretprovider.kubernetes;
 
 import io.gravitee.secretprovider.kubernetes.client.api.K8sClient;
 import io.gravitee.secretprovider.kubernetes.config.K8sSecretLocation;
-import io.gravitee.secrets.api.core.*;
+import io.gravitee.secrets.api.core.SecretEvent;
+import io.gravitee.secrets.api.core.SecretMap;
+import io.gravitee.secrets.api.core.SecretURL;
 import io.gravitee.secrets.api.errors.SecretManagerException;
 import io.gravitee.secrets.api.plugin.SecretProvider;
 import io.reactivex.rxjava3.core.Flowable;
@@ -37,20 +39,20 @@ public class KubernetesSecretProvider implements SecretProvider {
     }
 
     @Override
-    public Maybe<SecretMap> resolve(SecretMount secretMount) {
-        K8sSecretLocation k8sLocation = K8sSecretLocation.fromLocation(secretMount.location());
+    public Maybe<SecretMap> resolve(SecretURL secretURL) {
+        K8sSecretLocation k8sLocation = fromURL(secretURL);
         return client
             .getSecret(k8sLocation)
             .map(k8sSecret -> {
                 SecretMap sm = SecretMap.ofBase64(k8sSecret.getData());
-                handleWellKnownSecretKeys(sm, secretMount);
+                handleWellKnownSecretKeys(sm, secretURL);
                 return sm;
             });
     }
 
     @Override
-    public Flowable<SecretEvent> watch(SecretMount secretMount) {
-        K8sSecretLocation k8sLocation = K8sSecretLocation.fromLocation(secretMount.location());
+    public Flowable<SecretEvent> watch(SecretURL secretURL) {
+        K8sSecretLocation k8sLocation = fromURL(secretURL);
         return client
             .watchSecret(k8sLocation)
             .map(event -> {
@@ -61,24 +63,18 @@ public class KubernetesSecretProvider implements SecretProvider {
                     return new SecretEvent(SecretEvent.Type.DELETED, new SecretMap(null));
                 }
                 SecretMap secretMap = SecretMap.ofBase64(event.getObject().getData());
-                handleWellKnownSecretKeys(secretMap, secretMount);
+                handleWellKnownSecretKeys(secretMap, secretURL);
                 return new SecretEvent(SecretEvent.Type.UPDATED, secretMap);
             });
     }
 
-    @Override
-    public SecretMount fromURL(SecretURL url) {
-        K8sSecretLocation k8sSecretLocation = K8sSecretLocation.fromURL(url, client.config());
-        return new SecretMount(url.provider(), new SecretLocation(k8sSecretLocation.asMap()), k8sSecretLocation.key(), url);
+    K8sSecretLocation fromURL(SecretURL url) {
+        return K8sSecretLocation.fromURL(url, client.config());
     }
 
-    private void handleWellKnownSecretKeys(SecretMap secretMap, SecretMount secretMount) {
+    private void handleWellKnownSecretKeys(SecretMap secretMap, SecretURL secretURL) {
         secretMap.handleWellKnownSecretKeys(
-            Optional
-                .ofNullable(secretMount.secretURL())
-                .map(SecretURL::wellKnowKeyMap)
-                .filter(map -> !map.isEmpty())
-                .orElse(DEFAULT_WELL_KNOW_KEY_MAP)
+            Optional.ofNullable(secretURL).map(SecretURL::wellKnowKeyMap).filter(map -> !map.isEmpty()).orElse(DEFAULT_WELL_KNOW_KEY_MAP)
         );
     }
 }

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
@@ -63,9 +63,7 @@ public class KubernetesSecretProvider implements SecretProvider {
                 SecretMap secretMap = SecretMap.ofBase64(event.getObject().getData());
                 handleWellKnownSecretKeys(secretMap, secretMount);
                 return new SecretEvent(SecretEvent.Type.UPDATED, secretMap);
-            })
-            .skip(1)
-            .startWith(resolve(secretMount).map(secretMap -> new SecretEvent(SecretEvent.Type.CREATED, secretMap)));
+            });
     }
 
     @Override

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
@@ -1,7 +1,6 @@
 package io.gravitee.secretprovider.kubernetes;
 
 import io.gravitee.node.api.secrets.SecretProvider;
-import io.gravitee.node.api.secrets.errors.SecretManagerConfigurationException;
 import io.gravitee.node.api.secrets.errors.SecretManagerException;
 import io.gravitee.node.api.secrets.model.*;
 import io.gravitee.secretprovider.kubernetes.client.api.K8sClient;
@@ -71,18 +70,7 @@ public class KubernetesSecretProvider implements SecretProvider {
 
     @Override
     public SecretMount fromURL(SecretURL url) {
-        if (!url.provider().equals(KubernetesSecretProvider.PLUGIN_ID)) {
-            throw new SecretManagerConfigurationException(
-                "URL is not valid for Kubernetes Secret Provider plugin. Should be %s%s//<secret>[:<data field>] but was: '%s'".formatted(
-                        PLUGIN_URL_SCHEME,
-                        PLUGIN_ID,
-                        url
-                    )
-            );
-        }
-
         K8sSecretLocation k8sSecretLocation = K8sSecretLocation.fromURL(url, client.config());
-
         return new SecretMount(url.provider(), new SecretLocation(k8sSecretLocation.asMap()), k8sSecretLocation.key(), url);
     }
 

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProvider.java
@@ -1,10 +1,10 @@
 package io.gravitee.secretprovider.kubernetes;
 
-import io.gravitee.node.api.secrets.SecretProvider;
-import io.gravitee.node.api.secrets.errors.SecretManagerException;
-import io.gravitee.node.api.secrets.model.*;
 import io.gravitee.secretprovider.kubernetes.client.api.K8sClient;
 import io.gravitee.secretprovider.kubernetes.config.K8sSecretLocation;
+import io.gravitee.secrets.api.core.*;
+import io.gravitee.secrets.api.errors.SecretManagerException;
+import io.gravitee.secrets.api.plugin.SecretProvider;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.Map;

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderFactory.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderFactory.java
@@ -1,9 +1,9 @@
 package io.gravitee.secretprovider.kubernetes;
 
-import io.gravitee.node.api.secrets.SecretProvider;
-import io.gravitee.node.api.secrets.SecretProviderFactory;
 import io.gravitee.secretprovider.kubernetes.client.K8sClientImpl;
 import io.gravitee.secretprovider.kubernetes.config.K8sConfig;
+import io.gravitee.secrets.api.plugin.SecretProvider;
+import io.gravitee.secrets.api.plugin.SecretProviderFactory;
 
 /**
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/config/K8sConfig.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/config/K8sConfig.java
@@ -1,8 +1,8 @@
 package io.gravitee.secretprovider.kubernetes.config;
 
-import static io.gravitee.node.api.secrets.util.ConfigHelper.getProperty;
+import static io.gravitee.secrets.api.util.ConfigHelper.getProperty;
 
-import io.gravitee.node.api.secrets.SecretManagerConfiguration;
+import io.gravitee.secrets.api.plugin.SecretManagerConfiguration;
 import java.util.Map;
 import java.util.Objects;
 import lombok.AccessLevel;

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocation.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocation.java
@@ -1,7 +1,7 @@
 package io.gravitee.secretprovider.kubernetes.config;
 
-import io.gravitee.node.api.secrets.model.SecretLocation;
-import io.gravitee.node.api.secrets.model.SecretURL;
+import io.gravitee.secrets.api.core.SecretLocation;
+import io.gravitee.secrets.api.core.SecretURL;
 import java.util.Map;
 import java.util.Objects;
 

--- a/src/main/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocation.java
+++ b/src/main/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocation.java
@@ -1,34 +1,12 @@
 package io.gravitee.secretprovider.kubernetes.config;
 
-import io.gravitee.secrets.api.core.SecretLocation;
 import io.gravitee.secrets.api.core.SecretURL;
-import java.util.Map;
-import java.util.Objects;
 
 /**
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
  * @author GraviteeSource Team
  */
 public record K8sSecretLocation(String namespace, String secret, String key) {
-    static final String LOCATION_NAMESPACE = "namespace";
-    static final String LOCATION_SECRET = "secret";
-    static final String LOCATION_KEY = "key";
-
-    public Map<String, Object> asMap() {
-        if (key == null) {
-            return Map.of(LOCATION_NAMESPACE, namespace, LOCATION_SECRET, secret);
-        }
-        return Map.of(LOCATION_NAMESPACE, namespace, LOCATION_SECRET, secret, LOCATION_KEY, key);
-    }
-
-    public static K8sSecretLocation fromLocation(SecretLocation location) {
-        return new K8sSecretLocation(
-            Objects.requireNonNull(location.get(LOCATION_NAMESPACE)),
-            Objects.requireNonNull(location.get(LOCATION_SECRET)),
-            location.get(LOCATION_KEY)
-        );
-    }
-
     public static K8sSecretLocation fromURL(SecretURL url, K8sConfig k8sConfig) {
         String namespace = url.query().get(SecretURL.WellKnownQueryParam.NAMESPACE).stream().findFirst().orElse(k8sConfig.getNamespace());
         return new K8sSecretLocation(namespace, url.path(), url.key());

--- a/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderFactoryTest.java
+++ b/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderFactoryTest.java
@@ -4,9 +4,9 @@ import static io.gravitee.secretprovider.kubernetes.test.TestUtils.newConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.gravitee.node.api.secrets.SecretProvider;
-import io.gravitee.node.api.secrets.model.SecretURL;
 import io.gravitee.secretprovider.kubernetes.config.K8sConfig;
+import io.gravitee.secrets.api.core.SecretURL;
+import io.gravitee.secrets.api.plugin.SecretProvider;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderFactoryTest.java
+++ b/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderFactoryTest.java
@@ -2,10 +2,8 @@ package io.gravitee.secretprovider.kubernetes;
 
 import static io.gravitee.secretprovider.kubernetes.test.TestUtils.newConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.gravitee.secretprovider.kubernetes.config.K8sConfig;
-import io.gravitee.secrets.api.core.SecretURL;
 import io.gravitee.secrets.api.plugin.SecretProvider;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -24,6 +22,5 @@ class KubernetesSecretProviderFactoryTest {
         SecretProvider secretProvider = new KubernetesSecretProviderFactory()
             .create(new K8sConfig(newConfig(Map.of("kubeConfigFile", "src/test/resources/config.yaml"))));
         assertThat(secretProvider).isInstanceOf(KubernetesSecretProvider.class);
-        assertThatCode(() -> secretProvider.fromURL(SecretURL.from("secret://kubernetes/foo"))).doesNotThrowAnyException();
     }
 }

--- a/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderTest.java
+++ b/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderTest.java
@@ -6,13 +6,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.gravitee.kubernetes.client.model.v1.Event;
 import io.gravitee.kubernetes.client.model.v1.Secret;
-import io.gravitee.node.api.secrets.model.SecretEvent;
-import io.gravitee.node.api.secrets.model.SecretMap;
-import io.gravitee.node.api.secrets.model.SecretMount;
-import io.gravitee.node.api.secrets.model.SecretURL;
 import io.gravitee.secretprovider.kubernetes.client.api.K8sClient;
 import io.gravitee.secretprovider.kubernetes.config.K8sConfig;
 import io.gravitee.secretprovider.kubernetes.config.K8sSecretLocation;
+import io.gravitee.secrets.api.core.SecretEvent;
+import io.gravitee.secrets.api.core.SecretMap;
+import io.gravitee.secrets.api.core.SecretMount;
+import io.gravitee.secrets.api.core.SecretURL;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.nio.charset.StandardCharsets;
@@ -114,8 +114,16 @@ class KubernetesSecretProviderTest {
             );
             SecretMap secretMap = result.blockingGet();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME)).isPresent().get().asString().isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD)).isPresent().get().asString().isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("changeme");
         }
 
         @Test
@@ -133,8 +141,16 @@ class KubernetesSecretProviderTest {
             assertThat(events).hasSize(1);
             SecretMap secretMap = events.get(0).secretMap();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE)).isPresent().get().asString().isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY)).isPresent().get().asString().isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("changeme");
         }
 
         @Test
@@ -147,8 +163,16 @@ class KubernetesSecretProviderTest {
 
             SecretMap secretMap = result.blockingGet();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME)).isPresent().get().asString().isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD)).isPresent().get().asString().isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("changeme");
         }
 
         @Test
@@ -162,8 +186,16 @@ class KubernetesSecretProviderTest {
             assertThat(events).hasSize(1);
             SecretMap secretMap = events.get(0).secretMap();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE)).isPresent().get().asString().isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY)).isPresent().get().asString().isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY))
+                .isPresent()
+                .get()
+                .extracting(io.gravitee.secrets.api.core.Secret::asString)
+                .isEqualTo("changeme");
         }
 
         @Test

--- a/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderTest.java
+++ b/src/test/java/io/gravitee/secretprovider/kubernetes/KubernetesSecretProviderTest.java
@@ -6,8 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.gravitee.kubernetes.client.model.v1.Event;
 import io.gravitee.kubernetes.client.model.v1.Secret;
-import io.gravitee.kubernetes.client.model.v1.Watchable;
-import io.gravitee.node.api.secrets.errors.SecretManagerConfigurationException;
 import io.gravitee.node.api.secrets.model.SecretEvent;
 import io.gravitee.node.api.secrets.model.SecretMap;
 import io.gravitee.node.api.secrets.model.SecretMount;
@@ -79,12 +77,6 @@ class KubernetesSecretProviderTest {
             assertThat(secretMount.key()).isNull();
             assertThat(secretMount.isKeyEmpty()).isTrue();
         }
-
-        @Test
-        void should_fail_returning_secret_mount() {
-            SecretURL url = SecretURL.from("secret://foo/secret/bar");
-            assertThatCode(() -> cut.fromURL(url)).isInstanceOf(SecretManagerConfigurationException.class);
-        }
     }
 
     @Nested
@@ -122,10 +114,8 @@ class KubernetesSecretProviderTest {
             );
             SecretMap secretMap = result.blockingGet();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME).get().asString()).isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD).get().asString()).isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME)).isPresent().get().asString().isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD)).isPresent().get().asString().isEqualTo("changeme");
         }
 
         @Test
@@ -143,10 +133,8 @@ class KubernetesSecretProviderTest {
             assertThat(events).hasSize(1);
             SecretMap secretMap = events.get(0).secretMap();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE).get().asString()).isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY).get().asString()).isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE)).isPresent().get().asString().isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY)).isPresent().get().asString().isEqualTo("changeme");
         }
 
         @Test
@@ -159,10 +147,8 @@ class KubernetesSecretProviderTest {
 
             SecretMap secretMap = result.blockingGet();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME).get().asString()).isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD).get().asString()).isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.USERNAME)).isPresent().get().asString().isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PASSWORD)).isPresent().get().asString().isEqualTo("changeme");
         }
 
         @Test
@@ -176,10 +162,8 @@ class KubernetesSecretProviderTest {
             assertThat(events).hasSize(1);
             SecretMap secretMap = events.get(0).secretMap();
             assertThat(secretMap).isNotNull();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE).get().asString()).isEqualTo("admin");
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY)).isPresent();
-            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY).get().asString()).isEqualTo("changeme");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.CERTIFICATE)).isPresent().get().asString().isEqualTo("admin");
+            assertThat(secretMap.wellKnown(SecretMap.WellKnownSecretKey.PRIVATE_KEY)).isPresent().get().asString().isEqualTo("changeme");
         }
 
         @Test

--- a/src/test/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocationTest.java
+++ b/src/test/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocationTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import io.gravitee.node.api.secrets.model.SecretLocation;
-import io.gravitee.node.api.secrets.model.SecretURL;
+import io.gravitee.secrets.api.core.SecretLocation;
+import io.gravitee.secrets.api.core.SecretURL;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -55,7 +55,7 @@ class K8sSecretLocationTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("goodLocation")
-    void should_build_from_location(String _name, Map<String, Object> location, boolean hasKey) {
+    void should_build_from_location(String name, Map<String, Object> location, boolean hasKey) {
         K8sSecretLocation k8sSecretLocation = K8sSecretLocation.fromLocation(new SecretLocation(location));
         assertThat(k8sSecretLocation.namespace()).isNotBlank();
         assertThat(k8sSecretLocation.secret()).isNotBlank();
@@ -74,7 +74,7 @@ class K8sSecretLocationTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("badLocation")
-    void should_fail_building_from_location(String _name, Map<String, Object> location) {
+    void should_fail_building_from_location(String name, Map<String, Object> location) {
         SecretLocation secretLocation = new SecretLocation(location);
         assertThatCode(() -> K8sSecretLocation.fromLocation(secretLocation)).isInstanceOf(NullPointerException.class);
     }

--- a/src/test/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocationTest.java
+++ b/src/test/java/io/gravitee/secretprovider/kubernetes/config/K8sSecretLocationTest.java
@@ -2,16 +2,13 @@ package io.gravitee.secretprovider.kubernetes.config;
 
 import static io.gravitee.secretprovider.kubernetes.test.TestUtils.newConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import io.gravitee.secrets.api.core.SecretLocation;
 import io.gravitee.secrets.api.core.SecretURL;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,62 +19,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class K8sSecretLocationTest {
-
-    @Test
-    void should_return_location_as_map() {
-        Map<String, Object> map = new K8sSecretLocation("foo", "bar", "baz").asMap();
-        assertThat(map).containsValues("foo", "bar", "baz");
-    }
-
-    @Test
-    void should_return_location_as_map_no_key() {
-        Map<String, Object> map = new K8sSecretLocation("foo", "bar", null).asMap();
-        assertThat(map).containsValues("foo", "bar");
-    }
-
-    public static Stream<Arguments> goodLocation() {
-        return Stream.of(
-            arguments(
-                "full",
-                Map.of(
-                    K8sSecretLocation.LOCATION_NAMESPACE,
-                    "foo",
-                    K8sSecretLocation.LOCATION_SECRET,
-                    "bar",
-                    K8sSecretLocation.LOCATION_KEY,
-                    "baz"
-                ),
-                true
-            ),
-            arguments("key less", Map.of(K8sSecretLocation.LOCATION_NAMESPACE, "foo", K8sSecretLocation.LOCATION_SECRET, "bar"), false)
-        );
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("goodLocation")
-    void should_build_from_location(String name, Map<String, Object> location, boolean hasKey) {
-        K8sSecretLocation k8sSecretLocation = K8sSecretLocation.fromLocation(new SecretLocation(location));
-        assertThat(k8sSecretLocation.namespace()).isNotBlank();
-        assertThat(k8sSecretLocation.secret()).isNotBlank();
-        if (hasKey) {
-            assertThat(k8sSecretLocation.key()).isNotBlank();
-        }
-    }
-
-    public static Stream<Arguments> badLocation() {
-        return Stream.of(
-            arguments("empty", Map.of()),
-            arguments("no namespace", Map.of(K8sSecretLocation.LOCATION_SECRET, "bar", K8sSecretLocation.LOCATION_KEY, "baz")),
-            arguments("no secret", Map.of(K8sSecretLocation.LOCATION_NAMESPACE, "bar", K8sSecretLocation.LOCATION_KEY, "baz"))
-        );
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("badLocation")
-    void should_fail_building_from_location(String name, Map<String, Object> location) {
-        SecretLocation secretLocation = new SecretLocation(location);
-        assertThatCode(() -> K8sSecretLocation.fromLocation(secretLocation)).isInstanceOf(NullPointerException.class);
-    }
 
     public static Stream<Arguments> urls() {
         return Stream.of(


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-7497

## Description

* Use gravitee-secret-api
* Remove constraint on URL starting with provider plugin
* Adapt to new SecretProvider contract 

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-APIM-7497-api-secrets-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secretprovider/gravitee-secret-provider-kubernetes/2.0.0-APIM-7497-api-secrets-SNAPSHOT/gravitee-secret-provider-kubernetes-2.0.0-APIM-7497-api-secrets-SNAPSHOT.zip)
  <!-- Version placeholder end -->
