### PR TITLE
fix(deps): bump gravitee-secret-api to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <gravitee-bom.version>8.1.20</gravitee-bom.version>
-        <gravitee-secret-api.version>1.0.0-alpha.3</gravitee-secret-api.version>
+        <gravitee-secret-api.version>1.0.0</gravitee-secret-api.version>
 
         <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
 


### PR DESCRIPTION
## Description

fix(deps): bump gravitee-secret-api to 1.0.0

## Additional context
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bump-secret-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secretprovider/gravitee-secret-provider-kubernetes/2.0.0-bump-secret-api-SNAPSHOT/gravitee-secret-provider-kubernetes-2.0.0-bump-secret-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
