### PR TITLE
chore: update renovate config to use presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,25 +1,3 @@
 {
-    "extends": ["config:base", ":label(dependencies)"],
-    "rebaseWhen": "conflicted",
-    "packageRules": [
-        {
-            "matchDatasources": ["orb"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "ci"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["patch", "minor"],
-            "automerge": true,
-            "automergeType": "branch",
-            "semanticCommitType": "chore"
-        },
-        {
-            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-            "matchUpdateTypes": ["major"],
-            "semanticCommitType": "chore"
-        }
-    ]
+    "extends": ["github>gravitee-io/renovate-config:plugin"]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-300

## Description

Update the renovate config to match the shared presets defined.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/secretprovider/gravitee-secret-provider-kubernetes/2.0.0/gravitee-secret-provider-kubernetes-2.0.0.zip)
  <!-- Version placeholder end -->
